### PR TITLE
feat: add verb choice tip under PROMPTS category

### DIFF
--- a/src/modules/tips/TipsPage.tsx
+++ b/src/modules/tips/TipsPage.tsx
@@ -45,6 +45,24 @@ export const TipsPage: React.FC<{ onBack: () => void }> = ({ onBack }) => {
       isExpanded: false,
     },
     {
+      id: "5",
+      title: "Choose your verb carefully",
+      content: (
+        <>
+          Words like{" "}
+          <span className="text-glacier-600">"explain"</span> or{" "}
+          <span className="text-glacier-600">"justify"</span> tend to trigger
+          longer responses and use more energy. When a short answer will do, try{" "}
+          <span className="text-glacier-600">"summarize,"</span>{" "}
+          <span className="text-glacier-600">"list,"</span> or{" "}
+          <span className="text-glacier-600">"classify"</span> instead. (Source:
+          Lancaster University, 2025).
+        </>
+      ),
+      category: "PROMPTS",
+      isExpanded: false,
+    },
+    {
       id: "3",
       title: "Skip polite fillers",
       content: (


### PR DESCRIPTION
Adds a new static tip card based on findings from "Green Prompting" (Lancaster University, 2026 — arxiv.org/abs/2503.10666), which found that prompts using verbs like "explain" and "justify" consistently generated longer responses and higher energy consumption across all three models tested, while "summarize," "list," and "classify" correlated with shorter, cheaper outputs.