### PR TITLE
feat(storage): all-time total accumulator (issue #47 PR-A)

### DIFF
--- a/src/lib/__tests__/storageService.test.ts
+++ b/src/lib/__tests__/storageService.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearAllTimeTotal,
+  getAllTimeTotal,
   getDailyRecord,
   getDailyRecords,
+  incrementAllTimeTotal,
   pruneOldRecords,
   upsertDailyRecord,
   type DailyRecord,
@@ -128,5 +131,79 @@ describe("pruneOldRecords", () => {
 
     expect(store[`day_${day366}`]).toBeUndefined();
     expect(store[`day_${day364}`]).toBeDefined();
+  });
+});
+
+describe("getAllTimeTotal", () => {
+  it("returns zeroed RollupTotal with empty byModel when no key exists", async () => {
+    const total = await getAllTimeTotal();
+
+    expect(total.energy_Wh).toBe(0);
+    expect(total.co2_g).toBe(0);
+    expect(total.water_ml).toBe(0);
+    expect(total.sessions).toBe(0);
+    expect(total.prompts).toBe(0);
+    expect(total.byModel).toEqual({});
+  });
+});
+
+describe("incrementAllTimeTotal", () => {
+  it("accumulates grand totals and byModel for a single product", async () => {
+    await incrementAllTimeTotal("Claude", { energy_Wh: 10, co2_g: 2, water_ml: 50, sessions: 1, prompts: 3 });
+    await incrementAllTimeTotal("Claude", { energy_Wh: 5, co2_g: 1, water_ml: 25, sessions: 1, prompts: 2 });
+
+    const total = await getAllTimeTotal();
+
+    expect(total.energy_Wh).toBe(15);
+    expect(total.co2_g).toBe(3);
+    expect(total.water_ml).toBe(75);
+    expect(total.sessions).toBe(2);
+    expect(total.prompts).toBe(5);
+    expect(total.byModel.Claude.energy_Wh).toBe(15);
+    expect(total.byModel.Claude.prompts).toBe(5);
+  });
+
+  it("tracks distinct products in byModel independently", async () => {
+    await incrementAllTimeTotal("Claude", { energy_Wh: 10, co2_g: 2, water_ml: 50, sessions: 1, prompts: 3 });
+    await incrementAllTimeTotal("ChatGPT", { energy_Wh: 8, co2_g: 1, water_ml: 30, sessions: 1, prompts: 2 });
+
+    const total = await getAllTimeTotal();
+
+    expect(Object.keys(total.byModel)).toHaveLength(2);
+    expect(total.byModel.Claude.energy_Wh).toBe(10);
+    expect(total.byModel.ChatGPT.energy_Wh).toBe(8);
+    expect(total.energy_Wh).toBe(18);
+  });
+
+  it("grand total energy_Wh equals sum of byModel entries", async () => {
+    await incrementAllTimeTotal("Claude", { energy_Wh: 12, co2_g: 0, water_ml: 0, sessions: 0, prompts: 0 });
+    await incrementAllTimeTotal("Gemini", { energy_Wh: 8, co2_g: 0, water_ml: 0, sessions: 0, prompts: 0 });
+
+    const total = await getAllTimeTotal();
+    const byModelSum = Object.values(total.byModel).reduce((s, m) => s + m.energy_Wh, 0);
+
+    expect(total.energy_Wh).toBe(20);
+    expect(byModelSum).toBe(20);
+  });
+});
+
+describe("clearAllTimeTotal", () => {
+  it("removes the all-time total key", async () => {
+    await incrementAllTimeTotal("Claude", { energy_Wh: 10, co2_g: 2, water_ml: 50, sessions: 1, prompts: 3 });
+    await clearAllTimeTotal();
+
+    const total = await getAllTimeTotal();
+
+    expect(total.energy_Wh).toBe(0);
+    expect(total.byModel).toEqual({});
+  });
+
+  it("pruneOldRecords does not touch the alltime_total key", async () => {
+    await incrementAllTimeTotal("Claude", { energy_Wh: 5, co2_g: 1, water_ml: 20, sessions: 1, prompts: 2 });
+    await pruneOldRecords();
+
+    const total = await getAllTimeTotal();
+
+    expect(total.energy_Wh).toBe(5);
   });
 });

--- a/src/lib/storageService.ts
+++ b/src/lib/storageService.ts
@@ -9,7 +9,20 @@ export interface DailyRecord {
   prompts: number;
 }
 
+export interface ModelTotal {
+  energy_Wh: number;
+  co2_g: number;
+  water_ml: number;
+  sessions: number;
+  prompts: number;
+}
+
+export interface RollupTotal extends ModelTotal {
+  byModel: Record<string, ModelTotal>;
+}
+
 const KEY_PREFIX = "day_";
+const ALLTIME_KEY = "alltime_total";
 
 function dateToKey(date: string): string {
   return `${KEY_PREFIX}${date}`;
@@ -85,6 +98,64 @@ export async function getDailyRecords(days: number): Promise<DailyRecord[]> {
       .filter((r): r is DailyRecord => r !== null);
   } catch {
     return [];
+  }
+}
+
+const ZERO_TOTAL = (): ModelTotal => ({
+  energy_Wh: 0,
+  co2_g: 0,
+  water_ml: 0,
+  sessions: 0,
+  prompts: 0,
+});
+
+export async function getAllTimeTotal(): Promise<RollupTotal> {
+  try {
+    const result = await browser.storage.local.get([ALLTIME_KEY]);
+    return (result[ALLTIME_KEY] as RollupTotal) ?? { ...ZERO_TOTAL(), byModel: {} };
+  } catch {
+    return { ...ZERO_TOTAL(), byModel: {} };
+  }
+}
+
+export async function incrementAllTimeTotal(
+  product: string,
+  sessionData: Partial<ModelTotal>
+): Promise<void> {
+  try {
+    const current = await getAllTimeTotal();
+
+    const updated: RollupTotal = {
+      energy_Wh: current.energy_Wh + (sessionData.energy_Wh ?? 0),
+      co2_g: current.co2_g + (sessionData.co2_g ?? 0),
+      water_ml: current.water_ml + (sessionData.water_ml ?? 0),
+      sessions: current.sessions + (sessionData.sessions ?? 0),
+      prompts: current.prompts + (sessionData.prompts ?? 0),
+      byModel: { ...current.byModel },
+    };
+
+    const existing = updated.byModel[product] ?? ZERO_TOTAL();
+    updated.byModel[product] = {
+      energy_Wh: existing.energy_Wh + (sessionData.energy_Wh ?? 0),
+      co2_g: existing.co2_g + (sessionData.co2_g ?? 0),
+      water_ml: existing.water_ml + (sessionData.water_ml ?? 0),
+      sessions: existing.sessions + (sessionData.sessions ?? 0),
+      prompts: existing.prompts + (sessionData.prompts ?? 0),
+    };
+
+    await browser.storage.local.set({ [ALLTIME_KEY]: updated });
+  } catch (error) {
+    console.error("AI Wattch: Failed to increment all-time total:", error);
+    throw error;
+  }
+}
+
+export async function clearAllTimeTotal(): Promise<void> {
+  try {
+    await browser.storage.local.remove([ALLTIME_KEY]);
+  } catch (error) {
+    console.error("AI Wattch: Failed to clear all-time total:", error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `ModelTotal` and `RollupTotal` types to `storageService.ts`
- Add `getAllTimeTotal()` — returns current running total (zeroed struct if no key yet)
- Add `incrementAllTimeTotal(product, sessionData)` — appends to grand total and `byModel[product]`
- Add `clearAllTimeTotal()` — removes the `alltime_total` key (used by PR-6 "Clear history")
- `pruneOldRecords` already only touches `day_*` keys — `alltime_total` is never pruned

## Test plan
- [ ] `npm test` — 11 tests pass (5 existing + 6 new)
- [ ] `npm run build` — clean build
- [ ] `getAllTimeTotal` returns zeros + empty `byModel` on first call
- [ ] `incrementAllTimeTotal` accumulates across multiple calls for same product
- [ ] Multi-product `byModel` tracked independently; grand total = sum of byModel
- [ ] `clearAllTimeTotal` zeroes everything; `pruneOldRecords` leaves `alltime_total` untouched

Closes #47 (partial — PR-A of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)