### PR TITLE
feat(product): toProduct normalizer for model-id → product name (issue #47 PR-F)

### DIFF
--- a/src/lib/__tests__/product.test.ts
+++ b/src/lib/__tests__/product.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { toProduct } from "../product";
+
+describe("toProduct", () => {
+  it("maps known Claude model ids to 'Claude'", () => {
+    expect(toProduct("claude-opus-4-7")).toBe("Claude");
+    expect(toProduct("claude-sonnet-4-5")).toBe("Claude");
+    expect(toProduct("claude-haiku-4-5")).toBe("Claude");
+    expect(toProduct("claude-opus-3")).toBe("Claude");
+  });
+
+  it("maps known ChatGPT model ids to 'ChatGPT'", () => {
+    expect(toProduct("gpt-5")).toBe("ChatGPT");
+    expect(toProduct("gpt-4.1")).toBe("ChatGPT");
+    expect(toProduct("gpt-5.4")).toBe("ChatGPT");
+  });
+
+  it("maps known Gemini model ids to 'Gemini'", () => {
+    expect(toProduct("gemini-2.0-flash")).toBe("Gemini");
+    expect(toProduct("gemini-3-flash-preview")).toBe("Gemini");
+  });
+
+  it("all Claude model versions collapse to 'Claude'", () => {
+    const claudeIds = [
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-opus-4-5",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+      "claude-opus-4-1",
+      "claude-opus-4-0",
+      "claude-sonnet-4-0",
+      "claude-opus-3",
+    ];
+    for (const id of claudeIds) {
+      expect(toProduct(id)).toBe("Claude");
+    }
+  });
+
+  it("passes through unknown model id unchanged", () => {
+    expect(toProduct("unknown-model-xyz")).toBe("unknown-model-xyz");
+    expect(toProduct("gpt-9-super")).toBe("gpt-9-super");
+  });
+});

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -1,0 +1,18 @@
+import { LLM_MODELS } from "../constants/modelDefinitions";
+
+const PLATFORM_TO_PRODUCT: Record<string, string> = {
+  claude: "Claude",
+  chatgpt: "ChatGPT",
+  gemini: "Gemini",
+};
+
+const MODEL_ID_TO_PRODUCT = new Map<string, string>(
+  LLM_MODELS.map((m) => [
+    m.modelId,
+    PLATFORM_TO_PRODUCT[m.platform] ?? m.platform,
+  ])
+);
+
+export function toProduct(modelId: string): string {
+  return MODEL_ID_TO_PRODUCT.get(modelId) ?? modelId;
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/product.ts` with `toProduct(modelId: string): string`
- Looks up `modelId` in the local `LLM_MODELS` table, maps `platform` → product name (`claude` → `"Claude"`, `chatgpt` → `"ChatGPT"`, `gemini` → `"Gemini"`)
- Unknown ids pass through unchanged — new products still appear rather than being dropped
- No helper in `@antarctica-global/ai-wattch-constants` for this — local implementation confirmed appropriate
- 5 tests: known Claude/ChatGPT/Gemini ids, full Claude version collapse, unknown-id passthrough

## Test plan
- [ ] `npm test` — 10 tests pass (5 storage + 5 product)
- [ ] `npm run build` — clean build
- [ ] All Claude model versions (`claude-opus-4-7`, `claude-sonnet-4-5`, etc.) → `"Claude"`
- [ ] Unknown id returns itself unchanged

Closes #47 (partial — PR-F of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)