### PR TITLE
feat(background): write hooks + quota guard + startup prune (issue #47 PR-4)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -17,6 +17,12 @@ import {
 import { MESSAGE_TYPES } from "../constants";
 import { fetchUserLocationInternal } from "../shared/utils/locationService";
 import { defaultConsumptionByPlatform } from "../shared/utils/defaults";
+import {
+  upsertDailyRecord,
+  incrementAllTimeTotal,
+  pruneOldRecords,
+} from "../lib/storageService";
+import { toProduct } from "../lib/product";
 
 console.log("Service worker started");
 
@@ -44,6 +50,17 @@ const processAIMetrics = async (
       const consumption = await calculateConsumptionApi(metrics, settings);
       if (consumption) {
         await addMetricsToSession({ ...metrics, ...consumption });
+
+        const product = toProduct(metrics.modelId ?? "");
+        const dailyData = {
+          energy_Wh: (consumption.energyKWh ?? 0) * 1000,
+          co2_g: (consumption.carbonEmissionsKgCO2e ?? 0) * 1000,
+          water_ml: consumption.waterConsumption ?? 0,
+          sessions: 1,
+          prompts: 1,
+        };
+        await upsertDailyRecord(product, dailyData);
+        await incrementAllTimeTotal(product, dailyData);
       }
     } else {
       const sessionData = await getTodaySessionData();
@@ -397,6 +414,11 @@ const reloadAllowedTabs = async (): Promise<void> => {
     console.error("AI Watch: Error during tab reload:", error);
   }
 };
+
+// Prune old daily records on each browser startup
+chrome.runtime.onStartup.addListener(() => {
+  pruneOldRecords();
+});
 
 // Handle extension installation and updates
 chrome.runtime.onInstalled.addListener((details) => {

--- a/src/lib/__tests__/storageService.test.ts
+++ b/src/lib/__tests__/storageService.test.ts
@@ -12,6 +12,8 @@ import {
 
 // In-memory store backing the mock
 let store: Record<string, unknown> = {};
+// Controlled return value for getBytesInUse — 0 means "not over quota"
+let mockBytesInUse = 0;
 
 vi.mock("../../lib/browserApi", () => ({
   browser: {
@@ -29,6 +31,7 @@ vi.mock("../../lib/browserApi", () => ({
         remove: vi.fn(async (keys: string[]) => {
           keys.forEach((k) => delete store[k]);
         }),
+        getBytesInUse: vi.fn(async () => mockBytesInUse),
       },
     },
   },
@@ -51,6 +54,7 @@ vi.mock("../browserApi", () => ({
         remove: vi.fn(async (keys: string[]) => {
           keys.forEach((k) => delete store[k]);
         }),
+        getBytesInUse: vi.fn(async () => mockBytesInUse),
       },
     },
   },
@@ -58,14 +62,15 @@ vi.mock("../browserApi", () => ({
 
 beforeEach(() => {
   store = {};
+  mockBytesInUse = 0;
   vi.clearAllMocks();
 });
 
 describe("upsertDailyRecord", () => {
   it("accumulates values across multiple calls on the same day", async () => {
-    await upsertDailyRecord({ energy_Wh: 10, co2_g: 5, water_ml: 100, sessions: 1, prompts: 3 });
-    await upsertDailyRecord({ energy_Wh: 20, co2_g: 8, water_ml: 200, sessions: 1, prompts: 5 });
-    await upsertDailyRecord({ energy_Wh: 5,  co2_g: 2, water_ml: 50,  sessions: 0, prompts: 1 });
+    await upsertDailyRecord("Claude", { energy_Wh: 10, co2_g: 5, water_ml: 100, sessions: 1, prompts: 3 });
+    await upsertDailyRecord("Claude", { energy_Wh: 20, co2_g: 8, water_ml: 200, sessions: 1, prompts: 5 });
+    await upsertDailyRecord("Claude", { energy_Wh: 5,  co2_g: 2, water_ml: 50,  sessions: 0, prompts: 1 });
 
     const today = new Date().toLocaleDateString("en-CA");
     const record = await getDailyRecord(today);
@@ -79,13 +84,39 @@ describe("upsertDailyRecord", () => {
   });
 
   it("creates a fresh record when none exists", async () => {
-    await upsertDailyRecord({ energy_Wh: 7, prompts: 1 });
+    await upsertDailyRecord("Claude", { energy_Wh: 7, prompts: 1 });
     const today = new Date().toLocaleDateString("en-CA");
     const record = await getDailyRecord(today);
 
     expect(record!.energy_Wh).toBe(7);
     expect(record!.co2_g).toBe(0);
     expect(record!.prompts).toBe(1);
+  });
+
+  it("accumulates byModel breakdown per product and keeps products separate", async () => {
+    await upsertDailyRecord("Claude", { energy_Wh: 10, co2_g: 2, water_ml: 50, sessions: 1, prompts: 3 });
+    await upsertDailyRecord("ChatGPT", { energy_Wh: 8, co2_g: 1, water_ml: 30, sessions: 1, prompts: 2 });
+    await upsertDailyRecord("Claude", { energy_Wh: 5, co2_g: 1, water_ml: 25, sessions: 0, prompts: 1 });
+
+    const today = new Date().toLocaleDateString("en-CA");
+    const record = await getDailyRecord(today);
+
+    expect(record!.energy_Wh).toBe(23);
+    expect(record!.byModel!.Claude.energy_Wh).toBe(15);
+    expect(record!.byModel!.Claude.prompts).toBe(4);
+    expect(record!.byModel!.ChatGPT.energy_Wh).toBe(8);
+    expect(record!.byModel!.ChatGPT.prompts).toBe(2);
+  });
+
+  it("skips the daily write when storage remains over quota after pruning", async () => {
+    mockBytesInUse = 5 * 1024 * 1024; // 5 MB > 4 MB threshold
+
+    await upsertDailyRecord("Claude", { energy_Wh: 10, co2_g: 2, water_ml: 50, sessions: 1, prompts: 1 });
+
+    const today = new Date().toLocaleDateString("en-CA");
+    const record = await getDailyRecord(today);
+
+    expect(record).toBeNull();
   });
 });
 

--- a/src/lib/storageService.ts
+++ b/src/lib/storageService.ts
@@ -30,6 +30,7 @@ export interface RollupTotal extends ModelTotal {
 
 const KEY_PREFIX = "day_";
 const ALLTIME_KEY = "alltime_total";
+const QUOTA_THRESHOLD_BYTES = 4 * 1024 * 1024; // 4 MB — stays under old 5 MB Chrome ceiling
 
 function dateToKey(date: string): string {
   return `${KEY_PREFIX}${date}`;
@@ -53,8 +54,28 @@ export async function getDailyRecord(date: string): Promise<DailyRecord | null> 
 }
 
 export async function upsertDailyRecord(
-  sessionData: Partial<DailyRecord>
+  product: string,
+  sessionData: Partial<ModelTotal>
 ): Promise<void> {
+  // Quota guard: prune first if near limit; skip write if still over after prune.
+  // Never blocks the all-time increment (caller's responsibility).
+  try {
+    const getBytesInUse = (browser.storage.local as unknown as { getBytesInUse?: () => Promise<number> }).getBytesInUse;
+    if (getBytesInUse) {
+      const bytesInUse = await getBytesInUse();
+      if (bytesInUse > QUOTA_THRESHOLD_BYTES) {
+        await pruneOldRecords();
+        const bytesAfterPrune = await getBytesInUse();
+        if (bytesAfterPrune > QUOTA_THRESHOLD_BYTES) {
+          console.warn("AI Wattch: Storage quota exceeded after prune, skipping daily write");
+          return;
+        }
+      }
+    }
+  } catch {
+    // getBytesInUse unavailable in some environments — proceed with write
+  }
+
   const today = new Date().toLocaleDateString("en-CA");
   const key = dateToKey(today);
 
@@ -69,6 +90,15 @@ export async function upsertDailyRecord(
       prompts: 0,
     };
 
+    const existingByModel = existing.byModel ?? {};
+    const existingProduct = existingByModel[product] ?? {
+      energy_Wh: 0,
+      co2_g: 0,
+      water_ml: 0,
+      sessions: 0,
+      prompts: 0,
+    };
+
     const updated: DailyRecord = {
       date: today,
       energy_Wh: existing.energy_Wh + (sessionData.energy_Wh ?? 0),
@@ -76,6 +106,16 @@ export async function upsertDailyRecord(
       water_ml: existing.water_ml + (sessionData.water_ml ?? 0),
       sessions: existing.sessions + (sessionData.sessions ?? 0),
       prompts: existing.prompts + (sessionData.prompts ?? 0),
+      byModel: {
+        ...existingByModel,
+        [product]: {
+          energy_Wh: existingProduct.energy_Wh + (sessionData.energy_Wh ?? 0),
+          co2_g: existingProduct.co2_g + (sessionData.co2_g ?? 0),
+          water_ml: existingProduct.water_ml + (sessionData.water_ml ?? 0),
+          sessions: existingProduct.sessions + (sessionData.sessions ?? 0),
+          prompts: existingProduct.prompts + (sessionData.prompts ?? 0),
+        },
+      },
     };
 
     await browser.storage.local.set({ [key]: updated });


### PR DESCRIPTION
## Summary

- **`upsertDailyRecord(product, data)`** — updated signature to take a product name first; now accumulates `byModel` per-product breakdown alongside grand totals. Existing stored records without `byModel` are read defensively (treated as `{}`).
- **Quota guard** — before each daily write, checks `browser.storage.local.getBytesInUse()`; if over ~4 MB, prunes oldest daily records first; if still over, skips the write and logs a warning. The all-time increment is never blocked by this guard.
- **Background wiring** — on each prompt completion: `toProduct(modelId)` → `upsertDailyRecord(product, data)` + `incrementAllTimeTotal(product, data)`. Unit conversion: `energyKWh × 1000 → energy_Wh`, `carbonEmissionsKgCO2e × 1000 → co2_g`, `waterConsumption` is already in ml.
- **Startup prune** — `chrome.runtime.onStartup` → `pruneOldRecords()`.
- **No `unlimitedStorage` permission** added to manifests.

## Test plan
- [ ] `npm test` — 24 tests pass (7 storage + 12 all-time + 5 product)
- [ ] `npm run build` — clean build
- [ ] `byModel` accumulates correctly per product across multiple calls
- [ ] Quota guard test: `getBytesInUse` mocked to 5 MB → write skipped, record absent
- [ ] `pruneOldRecords` still leaves `alltime_total` untouched

Closes #47 (partial — PR-4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)