### PR TITLE
feat(storage): injectable date params + dev seed helper (issue #47)

### DIFF
--- a/src/lib/__tests__/seedStorage.ts
+++ b/src/lib/__tests__/seedStorage.ts
@@ -1,0 +1,61 @@
+/**
+ * Dev/test-only helper — never import from production code.
+ * Writes synthetic backdated daily records so you can verify aggregation
+ * and pruning without waiting a year.
+ *
+ * Usage in a Vitest test:
+ *   import { seedDailyRecords } from "./seedStorage";
+ *   await seedDailyRecords(store, 366, new Date("2026-06-20"));
+ *
+ * Usage for manual QA (call from browser devtools via a test build only):
+ *   NOT wired into the production background script.
+ */
+
+import type { DailyRecord } from "../storageService";
+
+export interface SeedRecord extends Omit<DailyRecord, "date"> {}
+
+/**
+ * Populates an in-memory store object (as used in Vitest mocks) with
+ * `count` backdated daily records ending on `now`.
+ *
+ * @param store  The mutable store object backing the browser.storage mock.
+ * @param count  Number of days to seed (e.g. 366 to test pruning).
+ * @param now    Reference "today". Pass a fixed date so tests are deterministic.
+ */
+export function seedDailyRecords(
+  store: Record<string, unknown>,
+  count: number,
+  now: Date = new Date()
+): void {
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toLocaleDateString("en-CA");
+    const key = `day_${dateStr}`;
+    store[key] = {
+      date: dateStr,
+      energy_Wh: 10 + (i % 5) * 3,
+      co2_g: 2 + (i % 3),
+      water_ml: 50 + (i % 7) * 10,
+      sessions: 1,
+      prompts: 2 + (i % 4),
+      byModel: {
+        Claude: {
+          energy_Wh: 6 + (i % 5),
+          co2_g: 1,
+          water_ml: 30,
+          sessions: 1,
+          prompts: 1 + (i % 4),
+        },
+        ChatGPT: {
+          energy_Wh: 4 + (i % 3),
+          co2_g: 1,
+          water_ml: 20,
+          sessions: 0,
+          prompts: 1,
+        },
+      },
+    } satisfies DailyRecord;
+  }
+}

--- a/src/lib/storageService.ts
+++ b/src/lib/storageService.ts
@@ -40,8 +40,8 @@ function keyToDate(key: string): string {
   return key.slice(KEY_PREFIX.length);
 }
 
-export function getTodayKey(): string {
-  return dateToKey(new Date().toLocaleDateString("en-CA"));
+export function getTodayKey(date: Date = new Date()): string {
+  return dateToKey(date.toLocaleDateString("en-CA"));
 }
 
 export async function getDailyRecord(date: string): Promise<DailyRecord | null> {
@@ -55,7 +55,8 @@ export async function getDailyRecord(date: string): Promise<DailyRecord | null> 
 
 export async function upsertDailyRecord(
   product: string,
-  sessionData: Partial<ModelTotal>
+  sessionData: Partial<ModelTotal>,
+  now: Date = new Date()
 ): Promise<void> {
   // Quota guard: prune first if near limit; skip write if still over after prune.
   // Never blocks the all-time increment (caller's responsibility).
@@ -64,7 +65,7 @@ export async function upsertDailyRecord(
     if (getBytesInUse) {
       const bytesInUse = await getBytesInUse();
       if (bytesInUse > QUOTA_THRESHOLD_BYTES) {
-        await pruneOldRecords();
+        await pruneOldRecords(now);
         const bytesAfterPrune = await getBytesInUse();
         if (bytesAfterPrune > QUOTA_THRESHOLD_BYTES) {
           console.warn("AI Wattch: Storage quota exceeded after prune, skipping daily write");
@@ -76,7 +77,7 @@ export async function upsertDailyRecord(
     // getBytesInUse unavailable in some environments — proceed with write
   }
 
-  const today = new Date().toLocaleDateString("en-CA");
+  const today = now.toLocaleDateString("en-CA");
   const key = dateToKey(today);
 
   try {
@@ -126,12 +127,12 @@ export async function upsertDailyRecord(
 }
 
 // Returns the last `days` days sorted oldest→newest, missing days omitted.
-export async function getDailyRecords(days: number): Promise<DailyRecord[]> {
+export async function getDailyRecords(days: number, now: Date = new Date()): Promise<DailyRecord[]> {
   const dates: string[] = [];
   const keys: string[] = [];
 
   for (let i = days - 1; i >= 0; i--) {
-    const d = new Date();
+    const d = new Date(now);
     d.setDate(d.getDate() - i);
     const dateStr = d.toLocaleDateString("en-CA");
     dates.push(dateStr);
@@ -207,8 +208,8 @@ export async function clearAllTimeTotal(): Promise<void> {
 }
 
 // Deletes any day_* key whose date is older than 365 days.
-export async function pruneOldRecords(): Promise<void> {
-  const cutoff = new Date();
+export async function pruneOldRecords(now: Date = new Date()): Promise<void> {
+  const cutoff = new Date(now);
   cutoff.setDate(cutoff.getDate() - 365);
   const cutoffStr = cutoff.toLocaleDateString("en-CA");
 


### PR DESCRIPTION
## Summary
- Add optional `now: Date = new Date()` parameter to `getTodayKey`, `upsertDailyRecord`, `getDailyRecords`, and `pruneOldRecords` so Vitest can simulate any date without mocking the global `Date`
- Add `src/lib/__tests__/seedStorage.ts` — test-only helper that writes backdated `day_*` records into the in-memory mock store for QA; never imported from production code
- Zero runtime behavior change — all new params default to `new Date()`

## Test plan
- [ ] `npm test` — 24/24 tests pass
- [ ] `npm run build` — clean build
- [ ] Verify `seedStorage.ts` is not bundled in `dist/` (it lives under `__tests__/`)
- [ ] Verify no direct `chrome.*` usage introduced
- [ ] Linked to issue #47

Closes #47 (testability milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)